### PR TITLE
rename function name toSFs -> toRSFs

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -45,7 +45,7 @@ func toVs(v []reflect.Value) []Value {
 	return out
 }
 
-func toSFs(v []StructField) []reflect.StructField {
+func toRSFs(v []StructField) []reflect.StructField {
 	out := make([]reflect.StructField, len(v))
 	for idx, vv := range v {
 		out[idx] = toRSF(vv)

--- a/type.go
+++ b/type.go
@@ -34,7 +34,7 @@ func sliceOf(t Type) Type {
 }
 
 func structOf(fields []StructField) Type {
-	return ToType(reflect.StructOf(toSFs(fields)))
+	return ToType(reflect.StructOf(toRSFs(fields)))
 }
 
 //go:linkname type_Align reflect.(*rtype).Align


### PR DESCRIPTION
Currently, `func toSFs` returns `[]reflect.StructField`.

I think the function name should be `toRSFs` like other functions which returns `reflect.*`
