### PR TITLE
Fix unsafe use of pointers in sample code

### DIFF
--- a/benchmark_marshaler_test.go
+++ b/benchmark_marshaler_test.go
@@ -25,7 +25,7 @@ type buffer struct {
 	b []byte
 }
 
-type encoder func(*buffer, uintptr) error
+type encoder func(*buffer, unsafe.Pointer) error
 
 func Marshal(v interface{}) ([]byte, error) {
 
@@ -33,7 +33,6 @@ func Marshal(v interface{}) ([]byte, error) {
 	// Get type information and pointer from interface{} value without allocation.
 	typ, ptr := reflect.TypeAndPtrOf(v)
 	typeID := reflect.TypeID(typ)
-	p := uintptr(ptr)
 
 	// Technique 2.
 	// Reuse the buffer once allocated using sync.Pool
@@ -44,7 +43,7 @@ func Marshal(v interface{}) ([]byte, error) {
 	// Technique 3.
 	// builds a optimized path by typeID and caches it
 	if enc, ok := typeToEncoderMap.Load(typeID); ok {
-		if err := enc.(encoder)(buf, p); err != nil {
+		if err := enc.(encoder)(buf, ptr); err != nil {
 			return nil, err
 		}
 
@@ -61,7 +60,7 @@ func Marshal(v interface{}) ([]byte, error) {
 		return nil, err
 	}
 	typeToEncoderMap.Store(typeID, enc)
-	if err := enc(buf, p); err != nil {
+	if err := enc(buf, ptr); err != nil {
 		return nil, err
 	}
 
@@ -92,11 +91,11 @@ func compileStruct(typ reflect.Type) (encoder, error) {
 			return nil, err
 		}
 		offset := field.Offset
-		encoders = append(encoders, func(buf *buffer, p uintptr) error {
-			return enc(buf, p+offset)
+		encoders = append(encoders, func(buf *buffer, p unsafe.Pointer) error {
+			return enc(buf, unsafe.Pointer(uintptr(p)+offset))
 		})
 	}
-	return func(buf *buffer, p uintptr) error {
+	return func(buf *buffer, p unsafe.Pointer) error {
 		buf.b = append(buf.b, '{')
 		for _, enc := range encoders {
 			if err := enc(buf, p); err != nil {
@@ -109,8 +108,8 @@ func compileStruct(typ reflect.Type) (encoder, error) {
 }
 
 func compileInt(typ reflect.Type) (encoder, error) {
-	return func(buf *buffer, p uintptr) error {
-		value := *(*int)(unsafe.Pointer(p))
+	return func(buf *buffer, p unsafe.Pointer) error {
+		value := *(*int)(p)
 		buf.b = strconv.AppendInt(buf.b, int64(value), 10)
 		return nil
 	}, nil


### PR DESCRIPTION
benchmark_marshaler_test.go and its copy in the README demonstrated
unsafe conversion of uintptr -> unsafe.Pointer. Fixing this will
hopefully reduce the likelihood that users will write unsafe code.

-------

I noticed the unsafety while reading [this blog post](https://blog.gopheracademy.com/advent-2019/safe-use-of-unsafe-pointer/), which says:

> In effect, once we’ve converted an unsafe.Pointer to uintptr, we cannot safely convert it back to unsafe.Pointer, with the exception of one special case:

> > If p points into an allocated object, it can be advanced through the object by conversion to uintptr, addition of an offset, and conversion back to Pointer.

> In order to perform this pointer arithmetic iteration logic safely, we must perform the type conversions and pointer arithmetic all at once

As I understand, the reason that the old version was unsafe and this is not is that Go reserves the right for the garbage-collector to move objects, which may invalidate the uintptr pointing to the struct field before the field can be accessed. However, by doing the conversion to a uintptr, the pointer arithmetic, and the conversation back to an unsafe.Pointer in one statement, the value retains its pointer semantics through the whole operation and is guaranteed to be updated if the underlying object is moved.

(I don't believe the current GC actually moves objects, so probably the old version would always work... unless / until a new version of Go introduces this, at which point something like this could cause very rare breakages.)

Even though this code is meant as a benchmark and sample use-case, since users will try to copy this code to write similar code, it's probably best to demonstrate good practices that won't break in the future.

`go vet` validates that the old version was unsafe and the new version is not. Running the benchmark with the old and new versions of the code seemed to show equivalent performance and no additional allocations.