### PR TITLE
make kind compatible with golang reflect package

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -61,12 +61,15 @@ const (
 	Func
 	Interface
 	Map
-	Ptr
+	Pointer
 	Slice
 	String
 	Struct
 	UnsafePointer
 )
+
+// Ptr is the old name for the Pointer kind.
+const Ptr = Pointer
 
 const (
 	_             SelectDir = iota


### PR DESCRIPTION
In the new version of Golang, they replaced Ptr with Pointer